### PR TITLE
Add user argument

### DIFF
--- a/extended-history-analyzer.py
+++ b/extended-history-analyzer.py
@@ -2,11 +2,16 @@ import argparse
 import glob
 import json
 import logging
+import os
 import pandas as pd
 import plotly.express as px
 from typing import List, Dict, Any, Set, Tuple
 
 parser = argparse.ArgumentParser(description='Analyze Spotify streaming history data.')
+parser.add_argument('-u', '--user',
+                    help='The user whose data to analyze',
+                    default='chris',
+                    required=False)
 parser.add_argument('-v', '--verbose',
                     help='Increase output verbosity',
                     action='store_true',
@@ -649,9 +654,13 @@ if __name__ == "__main__":
         logging.basicConfig(level=logging.INFO, format="%(message)s")
 
     # Configuration
-    file_pattern = "data/chris/Streaming_History_Audio_*[0-9].json"  # Path to json files
+    file_pattern = f"data/{args.user}/Streaming_History_Audio_*[0-9].json"  # Path to json files
     output_file = "spotify_analysis_output.txt"
     target_artists = ["Coldplay"]
+
+    if not os.path.exists(file_pattern):
+        logging.warning(f'Check that user {args.user} has an entry in the data directory.')
+        raise ValueError(f'File {file_pattern} not found.')
 
     # Execution
     data = load_files(file_pattern)

--- a/extended-history-analyzer.py
+++ b/extended-history-analyzer.py
@@ -658,7 +658,7 @@ if __name__ == "__main__":
     output_file = "spotify_analysis_output.txt"
     target_artists = ["Coldplay"]
 
-    if not os.path.exists(file_pattern):
+    if not glob.glob(file_pattern):
         logging.warning(f'Check that user {args.user} has an entry in the data directory.')
         raise ValueError(f'File {file_pattern} not found.')
 


### PR DESCRIPTION
Add an argument to specify user. Uses `chris` by default for convenience.

Check is made to ensure the user's data exists before proceeding with request.